### PR TITLE
feat: add radarr -cutoff tag to search for cutoff unmet movies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ missarr sends search requests for missing episodes to Sonarr
 
 missarr offers [pre-compiled binaries](https://github.com/l3uddz/missarr/releases/latest) for Linux, macOS and Windows for each official release.
 
+Example install (installing to /opt/missarr on linux amd64):
+````
+cd /opt
+mkdir missarr && cd missarr
+curl -fLvo missarr https://github.com/jolbol1/missarr/releases/download/v1.2.0/missarr_v1.2.0_linux_amd64
+chmod +x missarr
+````
+
 Alternatively, you can build the Missarr binary yourself.
 To build missarr on your system, make sure:
 
@@ -58,6 +66,9 @@ Search for 10 seasons (without updating seasons cache) `missarr sonarr --limit 1
 Search for 10 movies: `missarr radarr --limit 10`
 
 Search for 10 movies (without updating movies cache) `missarr radarr --limit 10 --skip-refresh`
+
+Search for 10 movies with cutoff unmet: `missarr radarr --limit 10 --cutoff`
+
 
 ## Donate
 

--- a/cmd/missarr/radarr.go
+++ b/cmd/missarr/radarr.go
@@ -15,6 +15,7 @@ type RadarrCmd struct {
 	LastReleaseDate time.Duration `default:"72h" help:"How long before an item can be considered missing based on release date"`
 	SkipRefresh     bool          `default:"false" help:"Retrieve current missing from radarr"`
 	Delay           time.Duration `default:"0s" help:"Delay between search requests"`
+	Cutoff          bool          `default:"false" help:"Search Cutoff Unmet Items"`
 }
 
 func (r *RadarrCmd) Run(c *config, db *sql.DB, mg *migrate.Migrator) error {
@@ -44,7 +45,7 @@ func (r *RadarrCmd) Run(c *config, db *sql.DB, mg *migrate.Migrator) error {
 			Msg("Retrieved movies")
 
 		// refresh datastore
-		us, rs, fm, err = sc.RefreshStore(rm, time.Now().Add(-r.LastReleaseDate))
+		us, rs, fm, err = sc.RefreshStore(rm, time.Now().Add(-r.LastReleaseDate), r.Cutoff)
 		if err != nil {
 			return fmt.Errorf("missing to store: %w", err)
 		}

--- a/radarr/api.go
+++ b/radarr/api.go
@@ -34,6 +34,10 @@ func (c *Client) getSystemStatus() (*systemStatus, error) {
 	return b, nil
 }
 
+type MovieFile struct {
+	QualityCutoffNotMet bool
+}
+
 type MovieResponse struct {
 	SizeOnDisk     int       `json:"sizeOnDisk"`
 	Status         string    `json:"status"`
@@ -45,6 +49,7 @@ type MovieResponse struct {
 	IsAvailable    bool      `json:"isAvailable"`
 	Added          time.Time `json:"added"`
 	Id             int       `json:"id"`
+	MovieFile      MovieFile `json:"movieFile"`
 }
 
 func (c *Client) Movies() ([]MovieResponse, error) {

--- a/radarr/migrations/1_init.sql
+++ b/radarr/migrations/1_init.sql
@@ -2,5 +2,6 @@ CREATE TABLE IF NOT EXISTS movies (
     "movie" INTEGER NOT NULL,
     "release_date" DATETIME NOT NULL,
     "search_date" DATETIME NULL,
+    "type" VARCHAR(10),
     PRIMARY KEY(movie)
 )

--- a/radarr/migrations/2_init.sql
+++ b/radarr/migrations/2_init.sql
@@ -1,0 +1,1 @@
+ALTER TABLE movies ADD [type] VARCHAR(10) NOT NULL DEFAULT 'missing'


### PR DESCRIPTION
This adds cutoff unmet searching functionality to Missarr for Radarr. Similar to Wantarr, however works with v3 api.

use `--cutoff` tag on Radarr command to run for cutoff unmet items only.