### PR TITLE
feat: add sonarr --cutoff tag to search for cutoff unmet episodes

### DIFF
--- a/cmd/missarr/radarr.go
+++ b/cmd/missarr/radarr.go
@@ -24,6 +24,11 @@ func (r *RadarrCmd) Run(c *config, db *sql.DB, mg *migrate.Migrator) error {
 		r.Limit = 10
 	}
 
+	missingType := "missing"
+	if r.Cutoff {
+		missingType = "cutoff_unmet"
+	}
+
 	// init
 	sc, err := radarr.New(&c.Radarr, db, mg)
 	if err != nil {
@@ -47,10 +52,10 @@ func (r *RadarrCmd) Run(c *config, db *sql.DB, mg *migrate.Migrator) error {
 		// refresh datastore
 		us, rs, fm, err = sc.RefreshStore(rm, time.Now().Add(-r.LastReleaseDate), r.Cutoff)
 		if err != nil {
-			return fmt.Errorf("missing to store: %w", err)
+			return fmt.Errorf("%v to store: %w", missingType, err)
 		}
 		log.Info().
-			Int("missing_movies", us).
+			Int(fmt.Sprintf("%v_movies", missingType), us).
 			Int("completed_movies", rs).
 			Msg("Refreshed datastore")
 	} else {

--- a/cmd/missarr/sonarr.go
+++ b/cmd/missarr/sonarr.go
@@ -16,6 +16,7 @@ type SonarrCmd struct {
 	AllowSpecial bool          `default:"false" help:"Allow specials to be considered missing"`
 	SkipRefresh  bool          `default:"false" help:"Retrieve current missing from sonarr"`
 	Delay        time.Duration `default:"0s" help:"Delay between search requests"`
+	Cutoff       bool          `default:"false" help:"Search Cutoff Unmet Items"`
 }
 
 func (r *SonarrCmd) Run(c *config, db *sql.DB, mg *migrate.Migrator) error {
@@ -36,7 +37,7 @@ func (r *SonarrCmd) Run(c *config, db *sql.DB, mg *migrate.Migrator) error {
 	var us, rs int
 
 	if !r.SkipRefresh {
-		se, err = sc.Missing()
+		se, err = sc.Missing(r.Cutoff)
 		if err != nil {
 			return fmt.Errorf("retrieving missing: %w", err)
 		}
@@ -45,7 +46,7 @@ func (r *SonarrCmd) Run(c *config, db *sql.DB, mg *migrate.Migrator) error {
 			Msg("Retrieved missing episodes")
 
 		// refresh datastore
-		us, rs, fs, err = sc.RefreshStore(se, r.AllowSpecial, time.Now().Add(-r.LastAirDate))
+		us, rs, fs, err = sc.RefreshStore(se, r.AllowSpecial, time.Now().Add(-r.LastAirDate), r.Cutoff)
 		if err != nil {
 			return fmt.Errorf("missing to store: %w", err)
 		}

--- a/sonarr/api.go
+++ b/sonarr/api.go
@@ -49,9 +49,13 @@ type Episode struct {
 	Id                       int       `json:"id"`
 }
 
-func (c *Client) Missing() ([]Episode, error) {
+func (c *Client) Missing(cutoff bool) ([]Episode, error) {
 	// prepare request
-	reqURL, err := util.URLWithQuery(util.JoinURL(c.apiURL, "wanted", "missing"), url.Values{
+	missingType := "missing"
+	if cutoff {
+		missingType = "cutoff"
+	}
+	reqURL, err := util.URLWithQuery(util.JoinURL(c.apiURL, "wanted", missingType), url.Values{
 		"page":     []string{"1"},
 		"pageSize": []string{"100000"},
 		"sortDir":  []string{"desc"},

--- a/sonarr/migrations/2_add_missing_type.sql
+++ b/sonarr/migrations/2_add_missing_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE series ADD [type] VARCHAR(10) NOT NULL DEFAULT 'missing'


### PR DESCRIPTION
In the same way I did with Radarr, this allows you to use the `--cutoff` tag on the sonarr command.

It does not look like sonarr are going to remove the /wanted/cutoff endpoint so should be good to use.

I also changed the log messages to reflect the mode they were running in. 

